### PR TITLE
Bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "css-loader": "^0.28.7",
     "extract-text-webpack-plugin": "^3.0.0",
     "http-proxy-middleware": "^0.17.4",
-    "vue": "~2.4.4",
+    "vue": "^2.4.4",
     "vue-loader": "^13.0.5",
     "vue-template-compiler": "^2.4.4",
     "webpack": "^3.6.0",

--- a/src/components/calendar-month.vue
+++ b/src/components/calendar-month.vue
@@ -222,7 +222,7 @@ export default {
 				};
 				const ep = { details: e, slot: 0 };
 				const continued = e.startDate < weekStart;
-				const startOffset = continued ? 0 : Math.round(this.dayDiff(weekStart, e.startDate));
+				const startOffset = continued ? 0 : this.dayDiff(weekStart, e.startDate);
 				const toBeContinued = this.dayDiff(weekStart, e.endDate) > 7;
 				const span = Math.min(
 					7 - startOffset,

--- a/src/components/calendar-month.vue
+++ b/src/components/calendar-month.vue
@@ -222,7 +222,7 @@ export default {
 				};
 				const ep = { details: e, slot: 0 };
 				const continued = e.startDate < weekStart;
-				const startOffset = continued ? 0 : this.dayDiff(weekStart, e.startDate);
+				const startOffset = continued ? 0 : Math.round(this.dayDiff(weekStart, e.startDate));
 				const toBeContinued = this.dayDiff(weekStart, e.endDate) > 7;
 				const span = Math.min(
 					7 - startOffset,

--- a/src/components/mixin-calendarMath.js
+++ b/src/components/mixin-calendarMath.js
@@ -84,7 +84,7 @@ export default {
 		// ******************************
 
 		// Number of days between two dates (times must be 0)
-		dayDiff(d1, d2)				{ return (d2 - d1) / 86400000; },
+		dayDiff(d1, d2)				{ return Math.round((d2 - d1) / 86400000); },
 
 		// http://stackoverflow.com/questions/492994/compare-two-dates-with-javascript
 		isSameDate(d1, d2)			{ return d1.getTime() === d2.getTime(); },
@@ -136,4 +136,3 @@ export default {
 	},
 
 };
-


### PR DESCRIPTION
Updated package.json to use ^ for Vue. The tilde was keeping Vue on the 2.4.x branch while vue-template-compiler was upgrading to 2.5.x branch and they need to be the same version. Use either ~ or ^ for both.

Use Math.round() on the offset calculation so spanning over a daylight savings time period works. Fixes issue #12 