### PR TITLE
Make calendar flex vertically to fill calling app's container

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,19 +1,20 @@
 <template>
 	<div id="app">
+		<div class="app-description">
+			<h1>vue-calendar-month 1.5.2</h1>
 
-		<h1>vue-calendar-month 1.5.3</h1>
+			<p>Below is an example of vue-calendar-month. You can drag and drop events to change the start date (this
+				functionality is optional and controlled by the calling app).</p>
 
-		<p>Below is an example of vue-calendar-month. You can drag and drop events to change the start date (this
-			functionality is optional and controlled by the calling app).</p>
+			<p>Note that this demo page has some examples of custom styles -- the holiday icons. As you can see from the source,
+				it's easy to customize the style to meet your needs. I've purposefully tried to choose defaults that are modern
+				and clean without getting so complicated that they would be difficult to override.</p>
 
-		<p>Note that this demo page has some examples of custom styles -- the holiday icons. As you can see from the source,
-			it's easy to customize the style to meet your needs. I've purposefully tried to choose defaults that are modern
-			and clean without getting so complicated that they would be difficult to override.</p>
+			<h3>{{message}}</h3>
 
-		<h3>{{message}}</h3>
-
-		<button @click="clickTestAddEvent" :disabled="alreadyAdded">Add Event on 22nd-23rd</button>
-
+			<button @click="clickTestAddEvent" :disabled="alreadyAdded">Add Event on 22nd-23rd</button>
+		</div>
+		
 		<calendar-month
 			class="holiday-us-traditional holiday-us-official"
 			:show-date="showDate"
@@ -84,13 +85,28 @@ export default {
 
 <style>
 
+	html, body {
+		height: 100%;
+		margin: 0;
+	}
+
 	#app {
 		font-family: Calibri;
 		width: 80vw;
+		height: 100%;
 		min-width: 40em;
 		max-width: 100em;
 		margin-left: auto;
 		margin-right: auto;
+		display: flex;
+		flex-direction: column;
+	}
+	.app-description {
+		flex: 0 1 auto;
+	}
+	.calendar-month {
+		flex: 1 1 auto;
+		margin-bottom: 1em;
 	}
 
 	/*

--- a/src/components/calendar-month.vue
+++ b/src/components/calendar-month.vue
@@ -271,10 +271,16 @@ All CSS related to colors, border radius, etc. should be part of a theme.
 
 	/* Position/Flex */
 
-	.calendar-month .month,
+	/* Make the calendar flex vertically */
+	.calendar-month {
+		height: 100%;
+		display: flex;
+		flex-direction: column;
+	}
+	/* Set flex-grow and flex-shrink to 0 for header and dayList so they remain static */
 	.calendar-month .header,
-	.calendar-month .week,
 	.calendar-month .dayList {
+		flex: 0 0 auto;
 		display: flex;
 		width: 100%;
 		flex-wrap: wrap;
@@ -282,6 +288,22 @@ All CSS related to colors, border radius, etc. should be part of a theme.
 		justify-content: flex-start;
 		align-items: stretch;
 		align-content: flex-start;
+	}
+	/* The calendar grid should take up the remaining vertical space */
+	.calendar-month .month {
+		flex: 1 1 auto;
+		display: flex;
+		flex-direction: column;
+	}
+	/* Use flex basis of 0 on week row so all weeks will be same height regardless of content */
+	.calendar-month .week {
+		flex: 1 1 0;
+		display: flex;
+		flex-direction: row;
+		min-height: 2em;
+	}
+	.calendar-month .week .day {
+		flex: 1 1 auto;
 	}
 
 	.calendar-month .header {
@@ -307,13 +329,6 @@ All CSS related to colors, border radius, etc. should be part of a theme.
 		position: relative;
 		width: 14.285714%;
 		background-color: #fff;
-	}
-
-	/* Set min-height to 85% of width */
-	.calendar-month .week .day:before {
-		content: "";
-		display: block;
-		padding-top: 85%;
 	}
 
 	.calendar-month .day .content {


### PR DESCRIPTION
The calendar currently does well at filling the container horizontally. The vertical size is then calculated using an aspect ratio (85%). I've played around quite a bit with flexbox to come up with this solution. It will fill the calling app's container completely as though it were absolutely positioned. This will make it easier for the end user to get the size they want.

See what you think.

I also made a [Codepen](https://codepen.io/houseoftech/pen/yPbVYK?editors=1100) with a simpler layout for testing.