### PR TITLE
Handling drag events when user has set its own slot for events

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,9 +384,6 @@ A third stylesheet, `static/css/holidays-us.css`, shows how simple it is to use 
 # install dependencies
 npm install
 
-# serve with hot reload at localhost:8080
-npm run dev
-
 # build for production with minification
 npm run build
 ```

--- a/src/CalendarView.vue
+++ b/src/CalendarView.vue
@@ -384,7 +384,10 @@ export default {
 
 		handleEvent(bubbleEventName, bubbleParam) {
 			if (!this.enableDragDrop) return false
-			if (!this.currentDragEvent) return false // shouldn't happen
+			if (!this.currentDragEvent) { // shouldn't happen
+				// If current drag event is not set, check if user has set its own slot for events
+				if (!!!this.$scopedSlots['event']) return false
+			} 
 			this.$emit(bubbleEventName, this.currentDragEvent, bubbleParam)
 			return true
 		},

--- a/src/CalendarView.vue
+++ b/src/CalendarView.vue
@@ -382,7 +382,7 @@ export default {
 			return true
 		},
 
-		handleEvent(bubbleEventName, bubbleParam) {
+		handleDragEvent(bubbleEventName, bubbleParam) {
 			if (!this.enableDragDrop) return false
 			if (!this.currentDragEvent) { // shouldn't happen
 				// If current drag event is not set, check if user has set its own slot for events
@@ -393,21 +393,21 @@ export default {
 		},
 
 		onDragOver(day) {
-			this.handleEvent("drag-over-date", day)
+			this.handleDragEvent("drag-over-date", day)
 		},
 
 		onDragEnter(day, windowEvent) {
-			if (!this.handleEvent("drag-enter-date", day)) return
+			if (!this.handleDragEvent("drag-enter-date", day)) return
 			windowEvent.target.classList.add("draghover")
 		},
 
 		onDragLeave(day, windowEvent) {
-			if (!this.handleEvent("drag-leave-date", day)) return
+			if (!this.handleDragEvent("drag-leave-date", day)) return
 			windowEvent.target.classList.remove("draghover")
 		},
 
 		onDrop(day, windowEvent) {
-			if (!this.handleEvent("drop-on-date", day)) return
+			if (!this.handleDragEvent("drop-on-date", day)) return
 			windowEvent.target.classList.remove("draghover")
 		},
 


### PR DESCRIPTION
First of all, thank your for library. It's incredible easy to use, and very customizable. Great job!

I haven't found any "contributor guide", so if there is any change which doesn't fit your taste, let me know to improve them.

I've made one major change, and two minor changes.

First, using your library I've faced the issue that I cannot use drag-and-drop workflow, because the (prior) method _**handleEvent**_, check if _**currentDragEvent**_ is set or not. If not, doesn't let the events bubble up. Since I'm using slots for the events, the _**dragStart**_ event, doesn't set the **_currentDragEvent_** var. So what I've did is, if **_currentDragEvent_** isn't set, check if user has set slots for events.

Second, I've removed the script _**npm run dev**_ from README, because is not available anymore.

Third, I've changed the method _**handleEvent**_ name to _**handleDragEvent**_, since it's only used for drag events.

I hope you'll appreciate this changes and be critical (in a good way) with them.