### PR TITLE
Add ability to select days and apply a highlight class

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,12 +1,3 @@
 {
-	"presets": [
-		[
-			"env",
-			{
-				"targets": {
-					"browsers": ["> 1%", "last 2 versions", "not ie < 11"]
-				}
-			}
-		]
-	]
+	"presets": ["env"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,101 +1,116 @@
-
 ## Future?
-- Mobile-compatible drag and drop
-- Handles to drag events to make them longer or shorter
+
+* Mobile-compatible drag and drop
+* Handles to drag events to make them longer or shorter
 
 ## 3.0.0 (NOT STARTED)
-- CSS reorganization to rely less on complex cascading (easier theming)
-- More flexible header customization
-- IE11 support fix? (I'm losing my ability to test IE11 soon but plan to maintain compatibility for a bit longer, with some help)
+
+* CSS reorganization to rely less on complex cascading (easier theming)
+* More flexible header customization
+* IE11 support fix? (I'm losing my ability to test IE11 soon but plan to maintain compatibility for a bit longer, with some help)
+
+## 2.2.1 (2018.03.19)
+
+* Fix where babel was not transpiling appropriately for IE11 (#46)
+* Fix where "sticky" content was causing issues for IE11, which doesn't support sticky
 
 ## 2.2.0 (2018.03.18)
-- Removed the events deprecated in 2.1.0
-- Upgraded to Webpack 4
-- Moved version history to this CHANGELOG file
-- Moved some opinionated styles from the baseline (SFC) to the default theme.
-- Fixed event slot issue reported in #42 and #50 (thanks @lexuzieel!).
-- Added `zIndex` prop to event scoped slot properties.
-- Formatted to meet newer eslint rules.
-- Corrected some minor positioning issues with events (including removing remaining em-based borders)
-- The `click-event` and `drag-*` events events now passes the **normalized** event (same as the "event" named slot). You can access your original event (*which is the one you should modify*) using the `originalEvent` attribute. While this is a minor breaking change, I wasn't quite ready to move up to 3.0, and this does make the API more consistent in how it passes events back to the caller.
-- **Known issue:** Babel is not currently transpiling correctly to provide IE11 support. Looking for assistance.
+
+* Removed the events deprecated in 2.1.0
+* Upgraded to Webpack 4
+* Moved version history to this CHANGELOG file
+* Moved some opinionated styles from the baseline (SFC) to the default theme.
+* Fixed event slot issue reported in #42 and #50 (thanks @lexuzieel!).
+* Added `zIndex` prop to event scoped slot properties.
+* Formatted to meet newer eslint rules.
+* Corrected some minor positioning issues with events (including removing remaining em-based borders)
+* The `click-event` and `drag-*` events events now passes the **normalized** event (same as the "event" named slot). You can access your original event (_which is the one you should modify_) using the `originalEvent` attribute. While this is a minor breaking change, I wasn't quite ready to move up to 3.0, and this does make the API more consistent in how it passes events back to the caller.
+* **Known issue:** Babel is not currently transpiling correctly to provide IE11 support. Looking for assistance.
 
 ## 2.1.2 / 2.1.3 (2018.01.27)
-- Prevent click-date events for future dates when disableFuture is true (feature parity with disablePast). Fixes #40.
+
+* Prevent click-date events for future dates when disableFuture is true (feature parity with disablePast). Fixes #40.
 
 ## 2.1.0 / 2.1.1 (2018.01.25)
+
 The events below were renamed to make them kebab-case (for DOM template compatibility) and to refine the wording. The old event names, shown here, were deprecated in this version and removed in 2.2:
-- `clickDay`
-- `clickEvent`
-- `setShowDate`
-- `dragEventStart`
-- `dragEventEnterDate`
-- `dragEventLeaveDate`
-- `dragEventOverDate`
-- `dropEventOnDate`
+
+* `clickDay`
+* `clickEvent`
+* `setShowDate`
+* `dragEventStart`
+* `dragEventEnterDate`
+* `dragEventLeaveDate`
+* `dragEventOverDate`
+* `dropEventOnDate`
 
 ## 2.0.1 (2018.01.23)
-- Fixed `outsideOfMonth` logic bug, #38
+
+* Fixed `outsideOfMonth` logic bug, #38
 
 ## 2.0.0 (2018.01.01)
+
 Version 2.0 includes some major upgrades! Here are the new features:
 
-- Dates passed as strings are interpreted using *browser local* time, not UTC, which prevents the event from showing up on an unexpected date.
-- Optional display of start and/or end times of events, with options for formatting
-- Ability to view more than one month at a time
-- Week view (including multi-week)
-- Year view (including, but not necessarily sanely, multi-year support)
-- New named slot for `event`
-- All slots now pass back useful properties the caller can bring into their scope
-- The main grid is scrollable if it is too tall for the component
-- Each week is scrollable if its events are too tall for the week's row in the component
+* Dates passed as strings are interpreted using _browser local_ time, not UTC, which prevents the event from showing up on an unexpected date.
+* Optional display of start and/or end times of events, with options for formatting
+* Ability to view more than one month at a time
+* Week view (including multi-week)
+* Year view (including, but not necessarily sanely, multi-year support)
+* New named slot for `event`
+* All slots now pass back useful properties the caller can bring into their scope
+* The main grid is scrollable if it is too tall for the component
+* Each week is scrollable if its events are too tall for the week's row in the component
 
 This means there are some breaking changes:
-- The component is now called **calendar-view** rather than **calendar-month**, to better reflect the flexibility of the period shown. (The package is still `vue-simple-calendar`.)
-- Because of the above, the CSS class of the root element has also changed to **calendar-view**.
-- The CSS class of the element containing the body of the view has changed from **month** to **weeks**, since periods other than a single month can be shown.
-- If you pass dates as strings, they MUST be in ISO form ("yyyy-mm-dd hh:mm:ss"). The time portion is optional, and within time, the minutes and seconds are also optional.
-- The header has been refactored to take better advantage of flexbox, increase the header text size, and group the buttons. This should make it easier to customize, but if you have a custom theme, it may need some updates.
-- If the calendar is too short to view the entire period, the calendar body is scrollable (scroll bars are hidden, use touch or scroll wheel).
-- If an individual week is too short to view all events in the week, the week's events are scrollable (scroll bars are hidden, use touch or scroll wheel).
-- The minimum cell height is now 3em, to ensure that at least one event shows vertically, and if there are others to scroll to, a small part of the next one is visible.
-- Emitted drag and drop events pass the original calendar event, not just its id.
-- The `dragEventDragOverDate` event (undocumented) has been renamed as `dragEventOverDate`. Prior to 2.0, user events emitted the calendar event's *id* as the first argument rather than the calendar event itself. Since not all calendar events will have an ID and the parent will probably want access to the actual calendar event, I changed these Vue events to emit the original calendar event, not just its id.
-- The `dayList` slot has been replaced with `dayHeader`, and slot `day` has been renamed as `dayContent`.
-- The word `slot` in the sense of an event display row has been renamed as `eventRow` in the code and CSS to avoid confusion with Vue slots.
-- Up to 20 events per day are now supported (up from 10).
-- Some basic colors, borders, etc. have been moved from the default theme into the component's core CSS, allowing the component to have a more appealing look with no theme in place and a better starting point for custom themes.
-- Reversed the circle-arrow labels to return to the current period. These are now clockwise to "go forward" to return to the current period, counter-clockwise to "go back" to return to the current period.
+
+* The component is now called **calendar-view** rather than **calendar-month**, to better reflect the flexibility of the period shown. (The package is still `vue-simple-calendar`.)
+* Because of the above, the CSS class of the root element has also changed to **calendar-view**.
+* The CSS class of the element containing the body of the view has changed from **month** to **weeks**, since periods other than a single month can be shown.
+* If you pass dates as strings, they MUST be in ISO form ("yyyy-mm-dd hh:mm:ss"). The time portion is optional, and within time, the minutes and seconds are also optional.
+* The header has been refactored to take better advantage of flexbox, increase the header text size, and group the buttons. This should make it easier to customize, but if you have a custom theme, it may need some updates.
+* If the calendar is too short to view the entire period, the calendar body is scrollable (scroll bars are hidden, use touch or scroll wheel).
+* If an individual week is too short to view all events in the week, the week's events are scrollable (scroll bars are hidden, use touch or scroll wheel).
+* The minimum cell height is now 3em, to ensure that at least one event shows vertically, and if there are others to scroll to, a small part of the next one is visible.
+* Emitted drag and drop events pass the original calendar event, not just its id.
+* The `dragEventDragOverDate` event (undocumented) has been renamed as `dragEventOverDate`. Prior to 2.0, user events emitted the calendar event's _id_ as the first argument rather than the calendar event itself. Since not all calendar events will have an ID and the parent will probably want access to the actual calendar event, I changed these Vue events to emit the original calendar event, not just its id.
+* The `dayList` slot has been replaced with `dayHeader`, and slot `day` has been renamed as `dayContent`.
+* The word `slot` in the sense of an event display row has been renamed as `eventRow` in the code and CSS to avoid confusion with Vue slots.
+* Up to 20 events per day are now supported (up from 10).
+* Some basic colors, borders, etc. have been moved from the default theme into the component's core CSS, allowing the component to have a more appealing look with no theme in place and a better starting point for custom themes.
+* Reversed the circle-arrow labels to return to the current period. These are now clockwise to "go forward" to return to the current period, counter-clockwise to "go back" to return to the current period.
 
 #### Props Added in 2.0
+
 * `showEventTimes` - If true, shows the start and/or end time of an event beside the event title. Midnight is not shown, a midnight time is assumed to indicate an all-day or indeterminate time. (If you want to show midnight, use `00:00:01` and don't choose to show seconds.) The default is `false`.
 * `timeFormatOptions` - This takes an object containing `Intl.DateTimeFormat` options to be used to format the event times. The `locale` setting is automatically used. This option is ignored for browsers that don't support `Intl` (they will see the 24-hour, zero-padded time).
-* `displayPeriodUom` - The period type to show. By default this is `month`, *i.e.*, it shows a calendar in month-sized chunks. Other allowed values are `year` and `week`.
-* `displayPeriodCount` - The *number* of periods to show within the view. For example, if `displayPeriodUom` is `week` and `displayPeriodCount` is 2, the view will show a two-week period.
+* `displayPeriodUom` - The period type to show. By default this is `month`, _i.e._, it shows a calendar in month-sized chunks. Other allowed values are `year` and `week`.
+* `displayPeriodCount` - The _number_ of periods to show within the view. For example, if `displayPeriodUom` is `week` and `displayPeriodCount` is 2, the view will show a two-week period.
 
 ## 1.8.2 (2017.12.30)
-- A `dayList` slot was added.
-- A `day` slot was added.
-- A `header` slot was added (#32)
-- Fixed display issue (#33)
+
+* A `dayList` slot was added.
+* A `day` slot was added.
+* A `header` slot was added (#32)
+* Fixed display issue (#33)
 
 ## Older changes
 
-Date       | Version      | Notes
------------|--------------|--------
-2017.05.11 | 1.0.0        | First version
-2017.05.15 | 1.1.0        | Better demo styling; refactor code; add basic drag/drop capability; fix display issue when events not sorted by start date
-2017.05.20 | 1.2.0        | Redesigned to work around z-index context issue with multi-day events (events now positioned above days, weeks rendered individually). Significant improvements to handling of event slots and clipping when event content exceeds height/width.
-2017.05.21 | 1.3.0        | Fixed IE. Bad IE. Fixed CSS references to emoji. Default style adjustments. Clean up some old code. Add previous/next year buttons.
-2017.05.22 | 1.3.1        | Improved demo, first published to npm.
-2017.05.27 | 1.4.0        | Add new classes, move a few classes up to `calendar` node, rename a few classes to pascalCase for consistency.
-2017.07.16 | 1.5.0        | Clean up code, move date math to a mixin; allow `endDate`, `title`, and `id` to be optional; change so only core CSS (mostly position / metrics) is in the component, a separate CSS file contains the default theme. Reorganized and updated optional US holiday theme CSS file. Tweaked default theme and metrics for consistency and cleaner look. NOTE: the default component name is now `calendar-month`, as is the primary container's CSS class. This was done for possible future expansion to support other views (such as a week view) and to give the CSS a slightly more unique name without resorting to scoped CSS. The name of the npm package, repository, etc. remains vue-simple-calendar.
-2017.10.03 | 1.5.1        | Fix issue where months ending in Saturday did not show their last week. Moved mixin to component folder.
-2017.10.04 | 1.5.2        | Fix webpack issue with mixin import and Vue warning about non-primitive keys.
-2017.11.11 | 1.5.3        | Fix date differences over DST and toBeContinued logic (thanks @houseoftech and @sean-atomized!)
-2017.11.12 | 1.6.0        | Fix future/past classes. Tweaks to CSS to fix border render issue, simplify. Change height from aspect ratio to the height of the container (the reason for the minor version increment).
-2017.11.12 | 1.6.1        | Fix issues when events have a time other than midnight (they should be ignored). Add stylelint and vue lint, clean up package.json, other minor tweaks. Set browser compatibility to a minimum of IE10. Prevent issues from caching "today" value.
-2017.12.12 | 1.7.0        | Add `startingDayOfWeek` property to allow the calendar to optionally start on any desired day of the week
-2017.12.15 | 1.7.1        | Hopefully resolve reported babel preset error
-2017.12.17 | 1.8.0        | Split sample app to another repo, rebuild build/config scripts from scratch
-2017.12.17 | 1.8.1        | Add build for mixin
+| Date       | Version | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2017.05.11 | 1.0.0   | First version                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| 2017.05.15 | 1.1.0   | Better demo styling; refactor code; add basic drag/drop capability; fix display issue when events not sorted by start date                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| 2017.05.20 | 1.2.0   | Redesigned to work around z-index context issue with multi-day events (events now positioned above days, weeks rendered individually). Significant improvements to handling of event slots and clipping when event content exceeds height/width.                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| 2017.05.21 | 1.3.0   | Fixed IE. Bad IE. Fixed CSS references to emoji. Default style adjustments. Clean up some old code. Add previous/next year buttons.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| 2017.05.22 | 1.3.1   | Improved demo, first published to npm.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| 2017.05.27 | 1.4.0   | Add new classes, move a few classes up to `calendar` node, rename a few classes to pascalCase for consistency.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| 2017.07.16 | 1.5.0   | Clean up code, move date math to a mixin; allow `endDate`, `title`, and `id` to be optional; change so only core CSS (mostly position / metrics) is in the component, a separate CSS file contains the default theme. Reorganized and updated optional US holiday theme CSS file. Tweaked default theme and metrics for consistency and cleaner look. NOTE: the default component name is now `calendar-month`, as is the primary container's CSS class. This was done for possible future expansion to support other views (such as a week view) and to give the CSS a slightly more unique name without resorting to scoped CSS. The name of the npm package, repository, etc. remains vue-simple-calendar. |
+| 2017.10.03 | 1.5.1   | Fix issue where months ending in Saturday did not show their last week. Moved mixin to component folder.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| 2017.10.04 | 1.5.2   | Fix webpack issue with mixin import and Vue warning about non-primitive keys.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| 2017.11.11 | 1.5.3   | Fix date differences over DST and toBeContinued logic (thanks @houseoftech and @sean-atomized!)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| 2017.11.12 | 1.6.0   | Fix future/past classes. Tweaks to CSS to fix border render issue, simplify. Change height from aspect ratio to the height of the container (the reason for the minor version increment).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| 2017.11.12 | 1.6.1   | Fix issues when events have a time other than midnight (they should be ignored). Add stylelint and vue lint, clean up package.json, other minor tweaks. Set browser compatibility to a minimum of IE10. Prevent issues from caching "today" value.                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| 2017.12.12 | 1.7.0   | Add `startingDayOfWeek` property to allow the calendar to optionally start on any desired day of the week                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| 2017.12.15 | 1.7.1   | Hopefully resolve reported babel preset error                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| 2017.12.17 | 1.8.0   | Split sample app to another repo, rebuild build/config scripts from scratch                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| 2017.12.17 | 1.8.1   | Add build for mixin                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |

--- a/README.md
+++ b/README.md
@@ -384,9 +384,6 @@ A third stylesheet, `static/css/holidays-us.css`, shows how simple it is to use 
 # install dependencies
 npm install
 
-# serve with hot reload at localhost:8080
-npm run dev
-
 # build for production with minification
 npm run build
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vue-simple-calendar",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"description": "Simple calendar event control",
 	"author": "richardtallent <richard@tallent.us>",
 	"license": "MIT",
@@ -8,7 +8,8 @@
 	"repository": "https://github.com/richardtallent/vue-simple-calendar",
 	"private": false,
 	"scripts": {
-		"build": "rimraf ./dist && webpack --config ./webpack.config.js --mode production"
+		"build":
+			"rimraf ./dist && webpack --config ./webpack.config.js --mode production"
 	},
 	"dependencies": {
 		"babel-polyfill": "^6.26.0"
@@ -51,11 +52,7 @@
 		"node": ">= 6.0.0",
 		"npm": ">= 5.0.0"
 	},
-	"browserslist": [
-		"> 1%",
-		"last 2 versions",
-		"not ie < 11"
-	],
+	"browserslist": ["> 1%", "last 2 versions", "ie >= 11"],
 	"prettier": {
 		"useTabs": true,
 		"semi": false,
@@ -79,19 +76,14 @@
 		"globals": {
 			"Vue": true
 		},
-		"extends": [
-			"eslint:recommended",
-			"plugin:vue/recommended"
-		],
+		"extends": ["eslint:recommended", "plugin:vue/recommended"],
 		"rules": {
 			"vue/html-indent": "tab",
 			"vue/max-attributes-per-line": 3,
 			"no-console": "warn"
 		}
 	},
-	"eslintIgnore": [
-		"node_modules/*.*"
-	],
+	"eslintIgnore": ["node_modules/*.*"],
 	"postcss": {
 		"plugins": {
 			"autoprefixer": {}

--- a/src/CalendarMathMixin.js
+++ b/src/CalendarMathMixin.js
@@ -158,9 +158,11 @@ export default {
 			return d.getMonth() !== this.addDays(d, 1).getMonth()
 		},
 		isSelectedDay(d) {
-			return this.selectedDays.some(day => this.isSameDate(
+			var day = Object.keys(this.dateClasses).find(day => this.isSameDate(
 				this.fromIsoStringToLocalDate(day), d
 			));
+
+			return day ? this.dateClasses[day] : undefined;
 		},
 		// Courtesy https://stackoverflow.com/questions/33908299/javascript-parse-a-string-to-date-as-local-time-zone/42626876#42626876
 		fromIsoStringToLocalDate(s) {

--- a/src/CalendarMathMixin.js
+++ b/src/CalendarMathMixin.js
@@ -157,7 +157,11 @@ export default {
 		isLastDayOfMonth(d) {
 			return d.getMonth() !== this.addDays(d, 1).getMonth()
 		},
-
+		isSelectedDay(d) {
+			return this.selectedDays.some(day => this.isSameDate(
+				this.fromIsoStringToLocalDate(day), d
+			));
+		},
 		// Courtesy https://stackoverflow.com/questions/33908299/javascript-parse-a-string-to-date-as-local-time-zone/42626876#42626876
 		fromIsoStringToLocalDate(s) {
 			let ds = s.split(/\D/).map(s => Number(s))

--- a/src/CalendarView.vue
+++ b/src/CalendarView.vue
@@ -61,9 +61,9 @@
 							past: isInPast(day),
 							future: isInFuture(day),
 							last: isLastDayOfMonth(day),
-							lastInstance: isLastInstanceOfMonth(day),
-							highlight: isSelectedDay(day)
-						}
+							lastInstance: isLastInstanceOfMonth(day)
+						},
+						...getClassesForSelectedDay(day)
 					]"
 					class="day"
 					@click="onClickDay(day)"
@@ -183,10 +183,10 @@ export default {
 				return []
 			},
 		},
-		selectedDays: {
-		    type: Array,
+        dateClasses: {
+		    type: Object,
 			default() {
-		        return []
+		        return {}
 			}
 		}
 	},

--- a/src/CalendarView.vue
+++ b/src/CalendarView.vue
@@ -382,29 +382,32 @@ export default {
 			return true
 		},
 
-		handleEvent(bubbleEventName, bubbleParam) {
+		handleDragEvent(bubbleEventName, bubbleParam) {
 			if (!this.enableDragDrop) return false
-			if (!this.currentDragEvent) return false // shouldn't happen
+			if (!this.currentDragEvent) { // shouldn't happen
+				// If current drag event is not set, check if user has set its own slot for events
+				if (!!!this.$scopedSlots['event']) return false
+			} 
 			this.$emit(bubbleEventName, this.currentDragEvent, bubbleParam)
 			return true
 		},
 
 		onDragOver(day) {
-			this.handleEvent("drag-over-date", day)
+			this.handleDragEvent("drag-over-date", day)
 		},
 
 		onDragEnter(day, windowEvent) {
-			if (!this.handleEvent("drag-enter-date", day)) return
+			if (!this.handleDragEvent("drag-enter-date", day)) return
 			windowEvent.target.classList.add("draghover")
 		},
 
 		onDragLeave(day, windowEvent) {
-			if (!this.handleEvent("drag-leave-date", day)) return
+			if (!this.handleDragEvent("drag-leave-date", day)) return
 			windowEvent.target.classList.remove("draghover")
 		},
 
 		onDrop(day, windowEvent) {
-			if (!this.handleEvent("drop-on-date", day)) return
+			if (!this.handleDragEvent("drop-on-date", day)) return
 			windowEvent.target.classList.remove("draghover")
 		},
 

--- a/src/CalendarView.vue
+++ b/src/CalendarView.vue
@@ -629,6 +629,7 @@ and decorations like border-radius should be part of a theme.
 .calendar-view .week .day {
 	display: flex;
 	flex: 1 1 0;
+	position: relative; /* Fallback for IE11, which doesn't support sticky */
 	position: sticky; /* When week's events are scrolled, keep the day content fixed */
 	top: 0;
 }

--- a/src/CalendarView.vue
+++ b/src/CalendarView.vue
@@ -21,7 +21,7 @@
 					<button :disabled="!isPeriodIncrementAllowed(12)" class="nextYear" @click="onIncrementPeriod(12)"/>
 					<button class="currentPeriod" @click="onClickCurrentPeriod"/>
 				</div>
-				<div :class="{ 
+				<div :class="{
 						singleYear: periodStart.getFullYear() === periodEnd.getFullYear(), 
 						singleMonth: isSameMonth(periodStart, periodEnd) }"
 					class="periodLabel">
@@ -62,6 +62,7 @@
 							future: isInFuture(day),
 							last: isLastDayOfMonth(day),
 							lastInstance: isLastInstanceOfMonth(day),
+							highlight: isSelectedDay(day)
 						}
 					]"
 					class="day"
@@ -182,6 +183,12 @@ export default {
 				return []
 			},
 		},
+		selectedDays: {
+		    type: Array,
+			default() {
+		        return []
+			}
+		}
 	},
 
 	data: function() {


### PR DESCRIPTION
This is my first time contributing to open source projects.

Yesterday I opened an issue about the possibility to highlight days on the calendar. Today, I was digging into the source code but I didn't find a way to do that.

Now with this change, the user can pass an array of days and the calendar will apply a `highlight` class if the day match.

Example:

`selectedDays: [
                    '2018-04-06',
                    '2018-04-07'
                ]`

```
<calendar-view
   :selected-days="selectedDays">
</calendar-view>
```

If there is something wrong with this change I will be glad to fix it.

The issue I opened yesterday is [here](https://github.com/richardtallent/vue-simple-calendar/issues/55)