### PR TITLE
Added 'past' class to events to assist styling

### DIFF
--- a/src/CalendarView.vue
+++ b/src/CalendarView.vue
@@ -370,6 +370,7 @@ export default {
 				if (continued) ep.classes.push("continued")
 				if (this.dayDiff(weekStart, ep.endDate) > 6)
 					ep.classes.push("toBeContinued")
+				if (this.isInPast(ep.endDate)) ep.classes.push("past")
 				if (ep.originalEvent.url) ep.classes.push("hasUrl")
 				for (let d = 0; d < 7; d++) {
 					if (d === startOffset) {


### PR DESCRIPTION
Since events don't appear as children of `.cv-day`, I've added `.past` to the event classes so they can be styled.