### PR TITLE
Remove `day` parameter from `onClickEvent` method

### DIFF
--- a/src/components/CalendarView.vue
+++ b/src/components/CalendarView.vue
@@ -274,8 +274,8 @@ export default {
 			this.$emit("click-date", day)
 		},
 
-		onClickEvent(e, day) {
-			this.$emit("click-event", e, day)
+		onClickEvent(e) {
+			this.$emit("click-event", e)
 		},
 
 		/*


### PR DESCRIPTION
There is no `day` to pass, since the click event comes from the event's DOM layer, not the calendar grid layer.

Closes #105 